### PR TITLE
Add a 'rawlatex' option.

### DIFF
--- a/src/Text/BlogLiterately/LaTeX.hs
+++ b/src/Text/BlogLiterately/LaTeX.hs
@@ -12,11 +12,26 @@
 
 module Text.BlogLiterately.LaTeX
     (
-      wpTeXify
+      rawTeXify
+    , wpTeXify
     ) where
 
 import           Data.List   (isPrefixOf)
 import           Text.Pandoc
+
+-- | Pass LaTeX through unchanged.
+rawTeXify :: Pandoc -> Pandoc
+rawTeXify = bottomUp formatDisplayTex . bottomUp formatInlineTex
+  where formatInlineTex :: [Inline] -> [Inline]
+        formatInlineTex (Math InlineMath tex : is)
+          = (RawInline (Format "html") ("$" ++ tex ++ "$")) : is
+        formatInlineTex is = is
+
+        formatDisplayTex :: [Block] -> [Block]
+        formatDisplayTex (Para [Math DisplayMath tex] : bs)
+          = RawBlock (Format "html") ("\n\\[" ++ tex ++ "\\]\n")
+          : bs
+        formatDisplayTex bs = bs
 
 -- | WordPress can render LaTeX, but expects it in a special non-standard
 --   format (@\$latex foo\$@).  The @wpTeXify@ function formats LaTeX code

--- a/src/Text/BlogLiterately/Options.hs
+++ b/src/Text/BlogLiterately/Options.hs
@@ -25,6 +25,7 @@ module Text.BlogLiterately.Options
     , otherHighlight
     , litHaskell
     , toc
+    , rawlatex
     , wplatex
     , math
     , ghci
@@ -54,6 +55,7 @@ module Text.BlogLiterately.Options
     , otherHighlight'
     , litHaskell'
     , toc'
+    , rawlatex'
     , wplatex'
     , math'
     , ghci'
@@ -93,6 +95,7 @@ data BlogLiterately = BlogLiterately
                                            --   non-Haskell?
   , _litHaskell     :: Maybe Bool          -- ^ Parse as literate Haskell?
   , _toc            :: Maybe Bool          -- ^ Generate a table of contents?
+  , _rawlatex       :: Maybe Bool          -- ^ Pass LaTeX through unchanged?
   , _wplatex        :: Maybe Bool          -- ^ Format LaTeX for WordPress?
   , _math           :: Maybe String        -- ^ Indicate how to format math
   , _ghci           :: Maybe Bool          -- ^ Automatically process ghci sessions?
@@ -138,6 +141,7 @@ instance Monoid BlogLiterately where
     , _otherHighlight = Nothing
     , _litHaskell     = Nothing
     , _toc            = Nothing
+    , _rawlatex       = Nothing
     , _wplatex        = Nothing
     , _math           = Nothing
     , _ghci           = Nothing
@@ -167,6 +171,7 @@ instance Monoid BlogLiterately where
     , _otherHighlight = combine _otherHighlight
     , _litHaskell     = combine _litHaskell
     , _toc            = combine _toc
+    , _rawlatex       = combine _rawlatex
     , _wplatex        = combine _wplatex
     , _math           = combine _math
     , _ghci           = combine _ghci
@@ -212,6 +217,9 @@ litHaskell' = fromMaybe True . view litHaskell
 
 toc' :: BlogLiterately -> Bool
 toc'            = fromMaybe False . view toc
+
+rawlatex' :: BlogLiterately -> Bool
+rawlatex'        = fromMaybe False . view rawlatex
 
 wplatex' :: BlogLiterately -> Bool
 wplatex'        = fromMaybe False . view wplatex
@@ -308,6 +316,8 @@ blOpts = BlogLiterately
          &= help "generate a table of contents"
          &= explicit
        ]
+     , _rawlatex = def &= help "pass inline/display LaTeX through unchanged"
+                       &= name "rawlatex" &= name "r" &= explicit
      , _wplatex = def &= help "reformat inline LaTeX the way WordPress expects"
                   &= name "wplatex" &= name "w" &= explicit
      , _math    = def &= help "how to layout math, where --math=<pandoc-option>[=URL]"

--- a/src/Text/BlogLiterately/Options/Parse.hs
+++ b/src/Text/BlogLiterately/Options/Parse.hs
@@ -53,6 +53,7 @@ parseBLOption :: Parser BlogLiterately
 parseBLOption =
       parseField style        "style"         parseStr
   <|> parseField toc          "toc"           parseBool
+  <|> parseField rawlatex     "rawlatex"      parseBool
   <|> parseField wplatex      "wplatex"       parseBool
   <|> parseField math         "math"          parseStr
   <|> parseField litHaskell   "lit-haskell"   parseBool


### PR DESCRIPTION
I use the MathJax plugin on my hosted Wordpress blog, so I need LaTeX to pass through without any escaping.

The ``rawlatex`` option  turns on the Pandoc extensions ``tex_math_dollars`` and ``tex_math_single_backslash`` so that inline and display LaTeX passes through unchanged.